### PR TITLE
Add sdk examples from ProjectManager's updated repo readme

### DIFF
--- a/fern/docs/pages/overview.mdx
+++ b/fern/docs/pages/overview.mdx
@@ -12,6 +12,18 @@ Your team can get started with the ProjectManager API right away - here's how.
 
 3. Download the appropriate software development kit for your favorite programming language, or take a look at our example programs:
 
+## ProjectManager SDK Examples
+
+This repository contains example code demonstrating the use of the ProjectManager SDK and the REST API v4.
+
+| Language            | Program                                                                                    | Notes                                    |
+| --------------- | ----------------------------------------------------------------------------------------|---------------------------------------|
+| C#     | [PMTask](https://github.com/projectmgr/projectmanager-sdk-examples/blob/main/csharp/PmTask)                                                  | A command line application that demonstrates basic functionality like creating tasks. `Run with dotnet run`    |   
+| Python     | [Python Task List](https://github.com/projectmgr/projectmanager-sdk-examples/blob/main/python/python_task_list.py) | A basic program in Python that demonstrates connecting and retrieving tasks. `Run with python .\python_task_list.py`       |
+| Jupyter     | [Jupyter Task DataFrame](https://github.com/projectmgr/projectmanager-sdk-examples/blob/main/jupyter/TaskDataFrame.ipynb)                                                          | A simple Jupyter notebook that retrieves tasks and displays them in a dataframe. Open in Visual Studio Code    |
+| TypeScript       | [TypeScript Task List](https://github.com/projectmgr/projectmanager-sdk-examples/blob/main/typescript/src/index.ts)                                                              | A basic program in TypeScript that demonstrates connecting and retrieving tasks. `Run with npm start`      |
+| Supabase     | [Java Task List](https://github.com/projectmgr/projectmanager-sdk-examples/blob/main/java/src/main/java/com/example/ExampleApp.java)                                                                      | A simple Java console application that demonstrates connecting and retrieving tasks. `Run with mvn exec:java -D"exec.mainClass=com.example.ExampleApp"`    |
+
 ## SDKs
 
 <Cards>


### PR DESCRIPTION
This PR:
- Highlights SDK examples by adding a new H2 `ProjectManager SDK Examples`
- Add SDK Examples in the form of a table

<img width="1101" alt="Screenshot 2024-01-29 at 9 53 45 PM" src="https://github.com/fern-projectmanager/projectmanager-api/assets/10618376/2e5a3fb5-9c4e-4962-9f77-9bd1f055f0cc">

![Uploading Screenshot 2024-01-29 at 9.56.50 PM.png…]()

